### PR TITLE
Fix `JsonPointer::remove()` not handling sequential arrays correctly

### DIFF
--- a/src/JsonPointer.php
+++ b/src/JsonPointer.php
@@ -289,6 +289,7 @@ class JsonPointer
                             $isAssociative = true;
                             break;
                         }
+                        $i++;
                     }
                 }
 

--- a/tests/src/JsonPointerTest.php
+++ b/tests/src/JsonPointerTest.php
@@ -96,6 +96,13 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $s->one->two);
     }
 
+    public function testSequentialArrayIsPreserved()
+    {
+		$json = [ 'l1' => [ 0 => 'foo', 1 => 'bar', 2 => 'baz' ] ];
+		JsonPointer::remove($json, ['l1', '1'], JsonPointer::TOLERATE_ASSOCIATIVE_ARRAYS);
+		$this->assertSame('{"l1":["foo","baz"]}', json_encode($json));
+    }
+
 }
 
 class Sample


### PR DESCRIPTION
Bug: T349483